### PR TITLE
Update sample app for SDK 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,11 @@ arrives with the SDK. They are the types the SDK's API is expressed in.
 
 | Type | What it is |
 | --- | --- |
-| **Publication** | The digital flyer itself — the thing rendered on screen. It is a concept rather than a type you hold: you render one by passing a `PublicationIdentifiers` (either `Store` or `PostalCode`) to the `FlippPublication` composable. |
-| **`CorePublication`** | The *metadata* for one publication, returned by `PublicationRepository` — `globalId`, `merchantId`, `dates`, `details`, `language`, `tags`, and the `renderingMetadataTypes` it can be rendered as. Use it to build a browse or list screen, then call `toIdentifiers(storeCode)` to render the publication it describes. This was called `Publication` in 1.x. |
-| **`Offer`** | A purchasable deal inside a publication. Carries `pricing` (`OfferPricing`: price, sale price, percent/amount off, quantities, loyalty points), `offerDetails` (sale story, pre/post-price text, disclaimer), `details` (name, description, imagery), plus `products` and `dates`. Delivered to your delegate by `onTap(offer)`, `onLongPress(offer)` and `onScrollToFinished(offer)`. |
-| **`Promotion`** | A non-purchasable merchandising element inside a publication — a banner, a link, a call-out. Carries `details` and an `action` whose `ActionType` (`EXTERNAL_LINK`, `POPUP_URL`, `SECTION_LINK`, `SECTION_LABEL_LINK`, `CUSTOM_ACTION`, `NO_ACTION`) and `target` describe what activating it should do. Delivered by `onTap(promotion)` and `onScrollToFinished(promotion)`. |
+| **`CorePublication`** | The *metadata* for one publication. A Publication is what is rendered on screen, either in the traditional print format (SFML) or the new digital format (DVM). |
+| **`Offer`** | A purchasable deal inside a publication. Carries pricing information, product information, and other relevant data. |
+| **`Promotion`** | A non-purchasable merchandising element inside a publication — a banner, a link, a call-out. |
 
-Offers and Promotions both carry a `globalId`, which is the identifier the
-[Publication Controller](#publication-controller) uses to scroll to an item or to add and remove
-annotations on it.
+Entities such as CorePublications, Offers and Promotions all carry a `globalId`, which is their unique identifier among all the content.
 
 ## Quick Start <a name="quick-start"></a>
 1. Clone this repo
@@ -50,6 +47,8 @@ The SDK is built against JVM target 17 and its dependencies require `compileSdk 
 so the consuming module must use at least:
 
 ```kts
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 android {
     compileSdk = 36
 
@@ -69,17 +68,16 @@ kotlin {
 Your Kotlin version must be **2.2.20 or newer** — the SDK is compiled with 2.2.20, and older
 compilers reject its metadata.
 
+`compileSdk 36` also sets a floor on the build tooling: **AGP 8.9 or newer** and **Gradle
+8.11.1 or newer**. AGP 8.7 and earlier cannot compile against SDK 36 and will fail to resolve
+the SDK's dependencies.
+
 Ensure you've added internet permissions to your `AndroidManifest.xml`
 ```xml
 <uses-permission android:name="android.permission.INTERNET"/>
 ```
 
 ### Repository <a name="repository"></a>
-One repository is needed. Alongside the SDK it serves everything the SDK depends on that is
-not available publicly — `com.flipp:content` and the generated protobuf bindings content uses
-to talk to Flipp's backend. Everything else (androidx, Compose, okhttp, retrofit, protobuf,
-gson, kotlinx) comes from `google()` and `mavenCentral()`.
-
 Add the credentials provided by Flipp to `~/.gradle/gradle.properties` so they are never
 committed to source control:
 ```properties
@@ -119,12 +117,7 @@ dvm-sdk = { module = "com.flipp:dvm-sdk", version.ref = "dvmSdk" }
 implementation(libs.dvm.sdk)
 ```
 
-That is the only dependency you declare. `com.flipp:content` arrives transitively — its models
-(`Offer`, `Promotion`, `CorePublication`, ...) are the types the SDK's own API is expressed in,
-and it provides the `PublicationRepository` used to fetch the publication list, so you can
-import from `com.flipp.content.v2.*` without declaring it yourself.
-
-The protobuf artifacts that arrive transitively ship their `.proto` sources in both the Kotlin
+Some protobuf artifacts that arrive transitively ship their `.proto` sources in both the Kotlin
 and Java variants, so packaging needs a duplicate-resource rule:
 ```kts
 android {
@@ -162,7 +155,11 @@ class MyApplication : Application() {
 ### Fetching Publications
 The publication list is fetched with the `PublicationRepository` from `com.flipp:content`.
 Construct it with the client token and curator endpoint that the SDK resolved during
-initialization. Both methods are `suspend` and throw on failure.
+initialization.
+
+Both methods are `suspend`. Note that they do **not** throw — a network error, an invalid
+`clientToken` or any other failure comes back as an empty list, indistinguishable from a store
+that genuinely has no publications. Bear that in mind when deciding what to show the user.
 
 ```kotlin
 import com.flipp.content.v2.network.repository.PublicationRepository
@@ -173,7 +170,7 @@ private val publicationsRepository =
         baseUrl = DvmSdk.config.endpoints.curator,
     )
 
-// Publications for a known merchant + store
+// Fetch Publications for a known merchant + store
 val publications: List<CorePublication> =
     publicationsRepository.getPublicationsByStore(
         merchantId = merchantId,
@@ -181,7 +178,7 @@ val publications: List<CorePublication> =
         language = "en",
     )
 
-// Publications for a postal/ZIP code region
+// Fetch Publications for a postal/ZIP code region
 val publications: List<CorePublication> =
     publicationsRepository.getPublicationsByPostalCode(
         merchantId = merchantId,
@@ -301,7 +298,7 @@ interface PublicationRendererDelegate {
 ```
 
 ### Publication Controller
-A `PublicationController` is a way to perform actions on a `Publication`. It is provided in
+A `PublicationController` is a way to perform actions on a rendered Publication. It is provided in
 `PublicationRendererDelegate.onFinishLoad` and stays valid for the lifetime of that
 Publication.
 ```kotlin
@@ -328,6 +325,46 @@ interface PublicationController {
     fun setVisibility(isVisible: Boolean)
 }
 ```
+
+#### Annotations
+An `Annotation` is an image drawn on top of individual items in a rendered Publication.
+
+Define one with a `type` you choose, the image to draw, and the corner it anchors to. `width` and
+`height` are optional:
+
+```kotlin
+val circleAnnotation = Annotation(
+    type = "circleAnnotation",
+    imageUrl = "[YOUR IMAGE URL]",
+    position = AnnotationPosition.TOP_RIGHT,
+)
+```
+
+Register the definitions once the Publication has loaded, then apply them to items by `globalId`:
+
+```kotlin
+override fun onFinishLoad(
+    controller: PublicationController,
+    legacyIdMap: Map<Long, String>?,
+) {
+    controller.registerAnnotations(listOf(circleAnnotation))
+    controller.addAnnotations("circleAnnotation", listOf("id1", "id2", "id3"))
+    // you can also remove them with controller.removeAnnotations("circleAnnotation", listOf("id1", "id2", "id3"))
+}
+```
+
+A few things worth knowing:
+
+- Register per Publication. Every `FlippPublication` gets its own controller with no annotations
+  applied, so registration belongs in `onFinishLoad`.
+- You do not need to re-apply after a configuration change — the SDK re-registers and re-applies
+  everything itself when the page reloads.
+- The SDK does not persist annotations beyond the life of the Publication. Which items are clipped
+  is your app's state to store and re-apply on the next load.
+- More than one type can apply to the same item, so a "coupon" and a "clipped" badge can sit on
+  one Offer together.
+- `imageUrl` is loaded by the renderer, so it has to be reachable from the device rather than
+  bundled in your app.
 
 ## Upgrading from 1.x to 2.x <a name="upgrading"></a>
 2.0 was a breaking release. The main changes:

--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@
 ## Table of Contents
 
 - [About the SDK](#about)
+- [Key Types](#key-types)
 - [Quick Start](#quick-start)
 - [How to Integrate the SDK](#how-to)
+- [Upgrading from 1.x to 2.x](#upgrading)
 
 ## About the SDK <a name="about"></a>
 The Flipp Platform SDK allows mobile retailer apps to render publications in two
@@ -15,35 +17,99 @@ The DVM format renders publications in a dynamic way that maintains
 responsiveness and merchandising flexibility, while also providing a host of
 features to allow users to interact with offers.
 
+This sample app targets SDK version **2.1.0**.
+
+## Key Types <a name="key-types"></a>
+
+The models below come from `com.flipp:content` (package `com.flipp.content.v2.model`), which
+arrives with the SDK. They are the types the SDK's API is expressed in.
+
+| Type | What it is |
+| --- | --- |
+| **Publication** | The digital flyer itself — the thing rendered on screen. It is a concept rather than a type you hold: you render one by passing a `PublicationIdentifiers` (either `Store` or `PostalCode`) to the `FlippPublication` composable. |
+| **`CorePublication`** | The *metadata* for one publication, returned by `PublicationRepository` — `globalId`, `merchantId`, `dates`, `details`, `language`, `tags`, and the `renderingMetadataTypes` it can be rendered as. Use it to build a browse or list screen, then call `toIdentifiers(storeCode)` to render the publication it describes. This was called `Publication` in 1.x. |
+| **`Offer`** | A purchasable deal inside a publication. Carries `pricing` (`OfferPricing`: price, sale price, percent/amount off, quantities, loyalty points), `offerDetails` (sale story, pre/post-price text, disclaimer), `details` (name, description, imagery), plus `products` and `dates`. Delivered to your delegate by `onTap(offer)`, `onLongPress(offer)` and `onScrollToFinished(offer)`. |
+| **`Promotion`** | A non-purchasable merchandising element inside a publication — a banner, a link, a call-out. Carries `details` and an `action` whose `ActionType` (`EXTERNAL_LINK`, `POPUP_URL`, `SECTION_LINK`, `SECTION_LABEL_LINK`, `CUSTOM_ACTION`, `NO_ACTION`) and `target` describe what activating it should do. Delivered by `onTap(promotion)` and `onScrollToFinished(promotion)`. |
+
+Offers and Promotions both carry a `globalId`, which is the identifier the
+[Publication Controller](#publication-controller) uses to scroll to an item or to add and remove
+annotations on it.
+
 ## Quick Start <a name="quick-start"></a>
 1. Clone this repo
 2. Open `dvm-sample-android` in Android Studio
-3. Add your JFrog credentials in `settings.gradle.kts`
+3. Add the Artifactory credentials provided by Flipp to `~/.gradle/gradle.properties` (see
+   [Repository](#repository))
 4. Add your `clientToken` provided by Flipp in `DvmApplication.kt`
 5. Build and run the app
 
 ## How to Integrate the SDK <a name="how-to"></a>
-First, ensure you've added internet permissions to your `AndroidManifest.xml`
+
+### Requirements
+The SDK is built against JVM target 17 and its dependencies require `compileSdk 36`,
+so the consuming module must use at least:
+
+```kts
+android {
+    compileSdk = 36
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
+}
+```
+
+Your Kotlin version must be **2.2.20 or newer** — the SDK is compiled with 2.2.20, and older
+compilers reject its metadata.
+
+Ensure you've added internet permissions to your `AndroidManifest.xml`
 ```xml
 <uses-permission android:name="android.permission.INTERNET"/>
 ```
 
-Then add `maven` as a repository source with the artifactory url below and fill in your JFrog account credentials provided by Flipp.
+### Repository <a name="repository"></a>
+One repository is needed. Alongside the SDK it serves everything the SDK depends on that is
+not available publicly — `com.flipp:content` and the generated protobuf bindings content uses
+to talk to Flipp's backend. Everything else (androidx, Compose, okhttp, retrofit, protobuf,
+gson, kotlinx) comes from `google()` and `mavenCentral()`.
+
+Add the credentials provided by Flipp to `~/.gradle/gradle.properties` so they are never
+committed to source control:
+```properties
+artifactory_user=[PROVIDED BY FLIPP]
+artifactory_password=[PROVIDED BY FLIPP]
+```
+
+Then declare the repository in `settings.gradle.kts`:
 ```kts
-repositories {
-    maven {
-        url = uri("https://flipplib.jfrog.io/artifactory/dvm-sdk-android")
-        credentials {
-            username = "[PROVIDED BY FLIPP]"
-            password = "[PROVIDED BY FLIPP]"
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+
+        maven {
+            url = uri("https://flipplib.jfrog.io/artifactory/dvm-sdk-android")
+            credentials {
+                username = providers.gradleProperty("artifactory_user").orNull ?: ""
+                password = providers.gradleProperty("artifactory_password").orNull ?: ""
+            }
         }
     }
 }
 ```
-Then add it to your build configuration in `libs.version.toml` and `build.gradle.kts`
+
+### Dependencies
+Declare the SDK in `libs.versions.toml` and `build.gradle.kts`
 ```toml
 [versions]
-dvmSdk = "1.8.1"  # latest version
+dvmSdk = "2.1.0"
 
 [libraries]
 dvm-sdk = { module = "com.flipp:dvm-sdk", version.ref = "dvmSdk" }
@@ -52,182 +118,232 @@ dvm-sdk = { module = "com.flipp:dvm-sdk", version.ref = "dvmSdk" }
 ```kts
 implementation(libs.dvm.sdk)
 ```
-You'll also have to update your build.gradle
+
+That is the only dependency you declare. `com.flipp:content` arrives transitively — its models
+(`Offer`, `Promotion`, `CorePublication`, ...) are the types the SDK's own API is expressed in,
+and it provides the `PublicationRepository` used to fetch the publication list, so you can
+import from `com.flipp.content.v2.*` without declaring it yourself.
+
+The protobuf artifacts that arrive transitively ship their `.proto` sources in both the Kotlin
+and Java variants, so packaging needs a duplicate-resource rule:
+```kts
+android {
+    packaging {
+        resources {
+            pickFirsts += "**/*.proto"
+        }
+    }
+}
+```
+
 ### Initializing the SDK
-In your application class begin by initializing the SDK. Here you will provide your `clientToken` provided by Flipp.  
-**Note**: this must be done before any other functionality of the SDK will work - the SDK will throw an exception otherwise
+In your application class begin by initializing the SDK. Here you will provide your
+`clientToken` provided by Flipp.
+**Note**: this must be done before any other functionality of the SDK will work - the SDK
+will throw an exception otherwise
 ```kotlin
-import com.flipp.dvm_sdk_android.external.DVMSDK
 import android.app.Application
+import com.flipp.dvm.sdk.android.external.DvmSdk
 
 class MyApplication : Application() {
     override fun onCreate() {
         super.onCreate()
-        DVMSDK.initialize(
+        DvmSdk.initialize(
             clientToken = "[PROVIDED BY FLIPP]",
             context = this,
-            userId = "id-of-the-user-launching-the-app" [OPTIONAL]
+            userId = "id-of-the-user-launching-the-app", // OPTIONAL
         )
     }
 }
 ```
-- If a new user begins using the app without restarting (e.g logs out), then the user id can be assigned in the DvmSdk.config object
-### Publication Repository
-- The dvm-sdk-android provides a `PublicationRepository` with one exposed method `getPublications` that you will use to get Publications
+- If a new user begins using the app without restarting (e.g logs out), then the user id can
+  be reassigned via `DvmSdk.config.identifiers.userId`
+
+### Fetching Publications
+The publication list is fetched with the `PublicationRepository` from `com.flipp:content`.
+Construct it with the client token and curator endpoint that the SDK resolved during
+initialization. Both methods are `suspend` and throw on failure.
+
 ```kotlin
-/**
- * Fetches the PublicationList for a given [merchantId] and [storeCode]
- *
- * @param merchantId the merchantId
- * @param storeCode the store code
- * @param limit the max number of results
- * @param nextToken token for pagination and fetching subsequent results
- * @return Result containing a [PublicationList] or the [HttpNetworkException] that occurred
- */
-@RequiresPermission(INTERNET)
-suspend fun getPublications(
-    merchantId: String,
-    storeCode: String? = null,
-    limit: Int? = null,
-    nextToken: String? = null,
-): Result<PublicationList>
+import com.flipp.content.v2.network.repository.PublicationRepository
+
+private val publicationsRepository =
+    PublicationRepository(
+        authorization = DvmSdk.config.clientToken,
+        baseUrl = DvmSdk.config.endpoints.curator,
+    )
+
+// Publications for a known merchant + store
+val publications: List<CorePublication> =
+    publicationsRepository.getPublicationsByStore(
+        merchantId = merchantId,
+        storeCode = storeCode,
+        language = "en",
+    )
+
+// Publications for a postal/ZIP code region
+val publications: List<CorePublication> =
+    publicationsRepository.getPublicationsByPostalCode(
+        merchantId = merchantId,
+        postalCode = postalCode,
+        countryCode = countryCode,
+        language = "en",
+    )
 ```
 
 ### Rendering Publications
-A `FlippPublication` is a Jetpack Compose Composable function that is used to render a `Publication`. It requires a Publication instance given by the `PublicationRepository`.
+`FlippPublication` is a Jetpack Compose composable that renders a Publication. It is
+identified by a `PublicationIdentifiers` — either a `Store` or a `PostalCode` — and a
+`RenderingMetadataType` from the Publication's `renderingMetadataTypes`.
+
 ```kotlin
 /**
- * A composable function that renders a Publication to the screen
- *
  * @param modifier The modifier to be applied to the composable
- * @param identifiers The identifiers for a composable
+ * @param identifiers The identifiers for the publication
  * @param renderType The method of rendering the Publication
+ * @param language The language code, e.g en, fr
+ * @param longPressDurationMs The duration of a long-press action in ms, null if long-press
+ * support is not needed
+ * @param caching True if the Publication should be cached, false otherwise
+ * @param linkedOfferId The id of an Offer to guarantee is linked into the Publication
  * @param delegate The delegate for handling Publication events
+ * @param header Optional composable rendered above the publication
+ * @param footer Optional composable rendered below the publication
  */
+@Composable
 fun FlippPublication(
     modifier: Modifier = Modifier,
-    publication: Publication,
-    storeCode: String,
-    delegate: DvmRendererDelegate,
-    renderType: RenderType,
+    identifiers: PublicationIdentifiers,
+    renderType: RenderingMetadataType,
+    language: String = "en",
+    longPressDurationMs: Int? = null,
+    caching: Boolean = true,
+    linkedOfferId: String? = null,
+    delegate: PublicationRendererDelegate? = null,
+    header: (@Composable () -> Unit)? = null,
+    footer: (@Composable () -> Unit)? = null,
 )
 ```
 
-### Delegate Functions
-A delegate should also be provided which allows you to handle specific events related to the Publication.
+A `CorePublication` is turned into identifiers with the `toIdentifiers` extension:
 ```kotlin
-/**
- * Defines a delegate interface for handling Publication events
- *
- */
+FlippPublication(
+    identifiers = publication.toIdentifiers(storeCode),
+    renderType = RenderingMetadataType.DVM_TEMPLATE,
+    language = publication.language,
+    delegate = delegate,
+)
+```
+
+When a `header` and/or `footer` is provided they scroll together with the publication as one
+continuous surface, and pinch-zoom on the publication is disabled.
+
+### Delegate Functions
+A delegate can also be provided which allows you to handle specific events related to the
+Publication. Every method has a no-op default — override only the events you care about.
+```kotlin
 interface PublicationRendererDelegate {
-    /**
-     * Gets called once the Publication successfully loads
-     * @param controller a controller to perform actions on the Publication
-     * @param legacyIdMap a map from the legacy flyerItemIds to the new globalIds for each item in the Publication
-     */
+    /** Called once the Publication successfully loads */
     fun onFinishLoad(controller: PublicationController, legacyIdMap: Map<Long, String>?)
 
     /**
-     * Gets called if there is an error loading the Publication.
-     * @param error the type of error that occurred along with a message describing it in detail
+     * Called if there is an error loading the Publication. This is terminal for the
+     * FlippPublication instance that reported it — to retry, remove the composable and add
+     * it back so a new Publication session is started.
      */
     fun onFailedToLoad(error: PublicationError)
 
-    /**
-     * Gets called if the user taps on an Offer from within a Publication.
-     * @param offer the [Offer] the user tapped on
-     */
+    /** Called if the user taps an Offer */
     fun onTap(offer: Offer)
 
-    /**
-     * Gets called if there was an error after tapping an Offer.
-     * Note: this function does not get called if the user taps on something other than an Offer
-     * @param error a message describing the error
-     */
+    /** Called if the user taps a Promotion */
+    fun onTap(promotion: Promotion)
+
+    /** Called if the user taps a take-to-merchant (external link) target */
+    fun onTap(url: String)
+
+    /** Called if there was an error after tapping an Offer */
     fun onTapError(error: String)
 
     /**
-     * Gets called if the user long-pressing on an Offer from within a Publication.
-     * @param offer the [Offer] the user tapped on
+     * Called if the user long-presses an Offer. Only fires when longPressDurationMs was
+     * passed to FlippPublication
      */
     fun onLongPress(offer: Offer)
 
-    /**
-     * Gets called if there was an error after long-pressing an Offer.
-     * Note: this function does not get called if the user long-taps on something other than an Offer
-     * @param error a message describing the error
-     */
+    /** Called if there was an error after long-pressing an Offer */
     fun onLongPressError(error: String)
 
-    /**
-     * Gets called when the user scrolls within the Publication.
-     * @param flyerHeightPx The height of the flyer in pixels.
-     * @param viewportBottomOffsetPx The offset from the bottom of the viewport.
-     */
+    /** Called when the user scrolls within the Publication */
     fun onScroll(flyerHeightPx: Int, viewportBottomOffsetPx: Int)
 
-    /**
-     * Gets called after the host-app has requested a scroll-to action to occur and it is completed
-     * @param offer the offer of the item scrolled to if applicable
-     */
+    /** Called after a requested scroll-to action completes for an Offer target */
     fun onScrollToFinished(offer: Offer?)
 
-    /**
-     * Gets called when the user sees more than 50% of an Offer on screen
-     * @param offers The the offers seen
-     */
-    fun onImpression(offers: List<String>)
+    /** Called after a requested scroll-to action completes for a Promotion target */
+    fun onScrollToFinished(promotion: Promotion?)
 
-    /**
-     * Gets called when a user interacts with the publication or 6 seconds pass
-     */
+    /** Called when the user sees more than 50% of an Offer on screen */
+    fun onImpressionOffers(offers: List<String>)
+
+    /** Called when the user sees more than 50% of a Promotion on screen */
+    fun onImpressionPromotions(promotions: List<String>)
+
+    /** Called once the visit counts as engaged: the user interacts, or 6 seconds elapse */
     fun onEngagedVisit()
+
+    /**
+     * Called when the Publication's hydration returns post-processing strategy results,
+     * e.g. the offer-linking strategy used when a linkedOfferId is provided
+     */
+    fun onStrategyResults(results: List<StrategyResult>)
 }
 ```
+
 ### Publication Controller
-A `PublicationController` is a way to perform actions on a `Publication`, it is provided in `PublicationDelegate.onFinishLoad`. 
+A `PublicationController` is a way to perform actions on a `Publication`. It is provided in
+`PublicationRendererDelegate.onFinishLoad` and stays valid for the lifetime of that
+Publication.
 ```kotlin
-/**
- * Interface defining a set of publication actions.
- */
 interface PublicationController {
-    /**
-     * Scrolls to an item given a [globalId].
-     * @param globalId The identifier of the item to scroll to.
-     */
-    fun scrollTo(globalId: String) = Unit
+    /** Scrolls to an item given a globalId */
+    fun scrollTo(globalId: String)
 
     /**
-     * Registers a list of annotations to be used later.
-     * @param annotations The list of annotations to register.
+     * Registers annotation definitions. An Annotation's type must be registered before it
+     * can be applied with addAnnotations
      */
-    fun registerAnnotations(annotations: List<Annotation>) = Unit
+    fun registerAnnotations(annotations: List<Annotation>)
+
+    /** Adds annotations of a specific type to the given global IDs */
+    fun addAnnotations(type: AnnotationType, globalIds: Set<String>)
+
+    /** Removes annotations of a specific type from the given global IDs */
+    fun removeAnnotations(type: AnnotationType, globalIds: Set<String>)
 
     /**
-     * Adds annotations of a specific type to the given global IDs.
-     * @param type The type of the annotations.
-     * @param globalIds The set of global IDs to add the annotations to.
+     * Notifies the renderer whether the Publication is currently visible to the user.
+     * Becoming visible resets the engaged-visit timer
      */
-    fun addAnnotations(
-        type: AnnotationType,
-        globalIds: Set<String>,
-    ) = Unit
-
-    /**
-     * Removes annotations of a specific type from the given global IDs.
-     * @param type The type of the annotations.
-     * @param globalIds The set of global IDs to remove the annotations from.
-     */
-    fun removeAnnotations(
-        type: AnnotationType,
-        globalIds: Set<String>,
-    ) = Unit
-
-    /**
-     * Notifies that the Publication is or is not visible - if so it resets the ev timer
-     * @param setVisibility True if the Publication is visible to the user
-     */
-    fun setVisibility(isVisible: Boolean) = Unit
+    fun setVisibility(isVisible: Boolean)
 }
 ```
+
+## Upgrading from 1.x to 2.x <a name="upgrading"></a>
+2.0 was a breaking release. The main changes:
+
+| 1.x | 2.x |
+| --- | --- |
+| `com.flipp.dvm.sdk.android.external.models.*` | `com.flipp.content.v2.model.*` (from `com.flipp:content`) |
+| `Publication` | `CorePublication` |
+| `Pricing` | `OfferPricing`, with `Float` instead of `Double` prices |
+| `RenderType.DVM` / `RenderType.SFML` | `RenderingMetadataType.DVM_TEMPLATE`, `DVM_STATIC`, `SFML_VERTICAL`, `SFML_HORIZONTAL` |
+| `Publication.renderingTypes` | `CorePublication.renderingMetadataTypes` |
+| `Dates.validFrom` / `validTo` as `Date` | epoch seconds as `Long?` |
+| `Details.additionalInfo` values as `JsonPrimitive` | `JsonElement` — read with `.jsonPrimitive.contentOrNull` |
+| SDK's own `PublicationRepository.getPublications` returning `Result<PublicationList>` | content's `PublicationRepository.getPublicationsByStore` / `getPublicationsByPostalCode` returning `List<CorePublication>` and throwing on failure |
+| `onImpression(offers)` | `onImpressionOffers(offers)` and `onImpressionPromotions(promotions)` |
+
+Also new in 2.x: `PublicationIdentifiers.PostalCode` for locating a Publication without a
+store, `onTap(promotion)` and `onTap(url)` delegate callbacks, `onStrategyResults`, the
+`linkedOfferId` parameter, and the `header`/`footer` slots on `FlippPublication`.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -8,7 +10,7 @@ plugins {
 
 android {
     namespace = "com.flipp.dvm.sample.android"
-    compileSdk = 34
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.flipp.dvm.sample.android"
@@ -29,15 +31,25 @@ android {
             )
         }
     }
+    // The SDK is compiled against JVM target 17, so consumers must compile at 17 or higher.
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-    kotlinOptions {
-        jvmTarget = "11"
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     buildFeatures {
         compose = true
+    }
+    packaging {
+        resources {
+            // The protobuf Kotlin and Java artifacts both bundle .proto source files
+            pickFirsts += "**/*.proto"
+        }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
     }
 }
 

--- a/app/src/main/java/com/flipp/dvm/sample/android/MainViewModel.kt
+++ b/app/src/main/java/com/flipp/dvm/sample/android/MainViewModel.kt
@@ -2,17 +2,24 @@ package com.flipp.dvm.sample.android
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.flipp.dvm.sdk.android.external.PublicationRepository
-import com.flipp.dvm.sdk.android.external.models.Offer
-import com.flipp.dvm.sdk.android.external.models.Publication
+import com.flipp.content.v2.model.CorePublication
+import com.flipp.content.v2.model.Offer
+import com.flipp.content.v2.network.repository.PublicationRepository
+import com.flipp.dvm.sdk.android.external.DvmSdk
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 class MainViewModel : ViewModel() {
-    // Fetching and displaying publications
-    private val publicationsRepository = PublicationRepository()
-    private val _publicationListUiState: MutableStateFlow<UiState<Publication>> =
+    // Fetching and displaying publications. The repository comes from com.flipp:content, which the
+    // SDK exposes as part of its public API; point it at the SDK's configured curator endpoint.
+    private val publicationsRepository =
+        PublicationRepository(
+            authorization = DvmSdk.config.clientToken,
+            baseUrl = DvmSdk.config.endpoints.curator,
+        )
+
+    private val _publicationListUiState: MutableStateFlow<UiState<CorePublication>> =
         MutableStateFlow(UiState.Loading)
     val publicationListUiState get() = _publicationListUiState
 
@@ -30,26 +37,21 @@ class MainViewModel : ViewModel() {
     fun fetchPublications() {
         _publicationListUiState.value = UiState.Loading
         viewModelScope.launch {
-            publicationsRepository.getPublications(
-                merchantId = _merchantId.value,
-                storeCode = _storeCode.value,
-                language = "en"
-            ).onSuccess {
+            runCatching {
+                publicationsRepository.getPublicationsByStore(
+                    merchantId = _merchantId.value,
+                    storeCode = _storeCode.value,
+                    language = "en",
+                )
+            }.onSuccess { publications ->
                 _publicationListUiState.value =
-                    if (it.publications.isNotEmpty()) {
-                        UiState.Success(data = it.publications)
+                    if (publications.isNotEmpty()) {
+                        UiState.Success(data = publications)
                     } else {
                         UiState.Empty
                     }
             }.onFailure {
-                when (it) {
-                    is PublicationRepository.Companion.HttpNetworkException -> {
-                        _publicationListUiState.value = UiState.Failed(error = "${it.statusCode}: ${it.message}")
-                    }
-                    else -> {
-                        _publicationListUiState.value = UiState.Failed(error = "${it.message}")
-                    }
-                }
+                _publicationListUiState.value = UiState.Failed(error = "${it.message}")
             }
         }
     }
@@ -61,7 +63,6 @@ class MainViewModel : ViewModel() {
     fun onMerchantIdChanged(merchantId: String) {
         this._merchantId.value = merchantId.trim().filter { it.isDigit() }
     }
-
 }
 
 /**

--- a/app/src/main/java/com/flipp/dvm/sample/android/MainViewModel.kt
+++ b/app/src/main/java/com/flipp/dvm/sample/android/MainViewModel.kt
@@ -24,11 +24,11 @@ class MainViewModel : ViewModel() {
     val publicationListUiState get() = _publicationListUiState
 
     // Merchant id via user input or map
-    private var _merchantId = MutableStateFlow("2018")
+    private var _merchantId = MutableStateFlow("")
     val merchantId get() = _merchantId.asStateFlow()
 
     // Store code via user input or map
-    private var _storeCode = MutableStateFlow("1174")
+    private var _storeCode = MutableStateFlow("")
     val storeCode get() = _storeCode.asStateFlow()
 
     // The selected offer in the Publication

--- a/app/src/main/java/com/flipp/dvm/sample/android/navigation/Routes.kt
+++ b/app/src/main/java/com/flipp/dvm/sample/android/navigation/Routes.kt
@@ -3,7 +3,6 @@ package com.flipp.dvm.sample.android.navigation
 import android.os.Bundle
 import androidx.navigation.NavType
 import com.flipp.dvm.sdk.android.external.PublicationIdentifiers
-import com.flipp.dvm.sdk.android.external.models.RenderType
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
@@ -24,10 +23,17 @@ sealed interface Routes {
      * Screen that displays the FlippPublication with additional debugging information
 
      * @property identifiers Contains values to uniquely identify the Publication to load
-     * @property renderType The method of rendering the Publication on screen
+     * @property renderType The name of the [com.flipp.content.v2.model.RenderingMetadataType] to
+     * render the Publication with. Passed as a String because navigation routes only carry types
+     * it knows how to serialize
+     * @property language The language code to render the Publication in, e.g en, fr
      */
     @Serializable
-    data class PublicationScreen(val identifiers: PublicationIdentifiers, val renderType: RenderType) {
+    data class PublicationScreen(
+        val identifiers: PublicationIdentifiers,
+        val renderType: String,
+        val language: String,
+    ) {
         companion object {
             /**
              * This is used to serialize and deserialize the object from the composable route

--- a/app/src/main/java/com/flipp/dvm/sample/android/ui/composables/ItemDetails.kt
+++ b/app/src/main/java/com/flipp/dvm/sample/android/ui/composables/ItemDetails.kt
@@ -122,11 +122,6 @@ fun ItemDetails(
                 }
             }
         }
-        getV2SaleStory(pricing, offerDetails, details).let {
-            if (it.isNotEmpty()) {
-                Text(it)
-            }
-        }
         Spacer(modifier = Modifier.height(16.dp))
         validFrom?.let { vf ->
             validTo?.let { vt ->
@@ -151,66 +146,6 @@ fun ItemDetails(
         }
         Spacer(modifier = Modifier.height(8.dp))
     }
-}
-
-/**
- * Gets the v2 sale story of an [Offer]
- *
- * @param pricing the pricing information of the [Offer]
- * @param offerDetails the offer-details of the [Offer]
- * @param details the details of the [Offer]
- * @return the sale story
- */
-fun getV2SaleStory(
-    pricing: OfferPricing?,
-    offerDetails: OfferDetails?,
-    details: Details?,
-): String {
-    val labels = pricing?.labels
-    var saleStory = offerDetails?.saleStory ?: ""
-    val prePriceText = offerDetails?.prePriceText ?: ""
-
-    // Save labels
-    labels?.let {
-        if (it.contains("show-save")) saleStory = "SAVE $saleStory"
-    }
-
-    // Qualifying Quantity
-    if (pricing?.offerType == OfferType.BUY_X_GET_Y &&
-        pricing.percentOff != null &&
-        pricing.qualifyingQuantity != null &&
-        pricing.rewardQuantity != null
-    ) {
-        if (saleStory.isNotEmpty()) {
-            saleStory += " "
-        }
-        saleStory += "BUY ${pricing.qualifyingQuantity} GET ${pricing.rewardQuantity} ${pricing.percentOff}% OFF"
-    } else if (pricing?.qualifyingQuantity != null &&
-        !prePriceText.contains(Regex("Buy \\d+ Or More"))
-    ) {
-        if (saleStory.isNotEmpty()) {
-            saleStory += " "
-        }
-        saleStory += "WHEN YOU BUY ${pricing.qualifyingQuantity}"
-    }
-
-    // Loyalty
-    pricing?.loyaltyPoints?.let { loyaltyPoints ->
-        if (saleStory.isNotEmpty()) {
-            saleStory += ", "
-        }
-        saleStory += "PC Optimum $loyaltyPoints pts"
-        details?.additionalInfo?.get("loyalty_points_story")?.jsonPrimitive?.contentOrNull?.let { loyaltyPointsStory ->
-            if (loyaltyPointsStory.isNotEmpty()) {
-                saleStory += " $loyaltyPointsStory"
-            }
-        }
-        details?.additionalInfo?.get("loyalty_points_value")?.jsonPrimitive?.contentOrNull?.let { loyaltyValue ->
-            saleStory += ", $$loyaltyValue Value"
-        }
-    }
-
-    return saleStory
 }
 
 /**

--- a/app/src/main/java/com/flipp/dvm/sample/android/ui/composables/ItemDetails.kt
+++ b/app/src/main/java/com/flipp/dvm/sample/android/ui/composables/ItemDetails.kt
@@ -21,13 +21,15 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import com.flipp.content.v2.model.Details
+import com.flipp.content.v2.model.Offer
+import com.flipp.content.v2.model.OfferDetails
+import com.flipp.content.v2.model.OfferPricing
+import com.flipp.content.v2.model.OfferType
 import com.flipp.dvm.sample.android.ui.theme.Typography
-import com.flipp.dvm.sdk.android.external.models.Details
-import com.flipp.dvm.sdk.android.external.models.Offer
-import com.flipp.dvm.sdk.android.external.models.OfferDetails
-import com.flipp.dvm.sdk.android.external.models.OfferType
-import com.flipp.dvm.sdk.android.external.models.Pricing
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -59,7 +61,7 @@ fun ItemDetails(
     description: String?,
     disclaimer: String?,
     offerDetails: OfferDetails?,
-    pricing: Pricing?,
+    pricing: OfferPricing?,
     details: Details?,
 ) {
     val scrollState = rememberScrollState()
@@ -144,7 +146,7 @@ fun ItemDetails(
             Text(it)
         }
         Spacer(modifier = Modifier.height(8.dp))
-        details?.additionalInfo?.get("sku")?.content?.let {
+        details?.additionalInfo?.get("sku")?.jsonPrimitive?.contentOrNull?.let {
             Text("SKU: $it")
         }
         Spacer(modifier = Modifier.height(8.dp))
@@ -160,7 +162,7 @@ fun ItemDetails(
  * @return the sale story
  */
 fun getV2SaleStory(
-    pricing: Pricing?,
+    pricing: OfferPricing?,
     offerDetails: OfferDetails?,
     details: Details?,
 ): String {
@@ -198,12 +200,12 @@ fun getV2SaleStory(
             saleStory += ", "
         }
         saleStory += "PC Optimum $loyaltyPoints pts"
-        details?.additionalInfo?.get("loyalty_points_story")?.content?.let { loyaltyPointsStory ->
+        details?.additionalInfo?.get("loyalty_points_story")?.jsonPrimitive?.contentOrNull?.let { loyaltyPointsStory ->
             if (loyaltyPointsStory.isNotEmpty()) {
                 saleStory += " $loyaltyPointsStory"
             }
         }
-        details?.additionalInfo?.get("loyalty_points_value")?.content?.let { loyaltyValue ->
+        details?.additionalInfo?.get("loyalty_points_value")?.jsonPrimitive?.contentOrNull?.let { loyaltyValue ->
             saleStory += ", $$loyaltyValue Value"
         }
     }
@@ -219,7 +221,7 @@ fun getV2SaleStory(
  * @return the price mapping of the offer
  */
 fun getV2PriceMapping(
-    pricing: Pricing?,
+    pricing: OfferPricing?,
     offerDetails: OfferDetails?,
 ): V2PriceMapping {
     val prePriceText = offerDetails?.prePriceText ?: ""
@@ -270,8 +272,9 @@ fun ItemDetailsPreview() {
         images = listOf<String>(""),
         id = "01J8ZBC550B9R8ZZZFD58C0TRT",
         pricing =
-            Pricing(
-                price = 2.49,
+            OfferPricing(
+                price = 2.49f,
+                originalPriceEach = false,
             ),
         offerDetails =
             OfferDetails(

--- a/app/src/main/java/com/flipp/dvm/sample/android/ui/composables/PublicationCard.kt
+++ b/app/src/main/java/com/flipp/dvm/sample/android/ui/composables/PublicationCard.kt
@@ -3,11 +3,15 @@ package com.flipp.dvm.sample.android.ui.composables
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -15,10 +19,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
+import com.flipp.content.v2.model.RenderingMetadataType
 import com.flipp.dvm.sample.android.ui.theme.Typography
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -35,8 +40,8 @@ import java.util.Locale
  * @param validFrom the date the offer is valid from as a ISO-8601 string
  * @param validTo the date the offer is expires from as a ISO-8601 string
  * @param tags the list of tags associated with the Publication
- * @param onSfmlClick called when the user clicks the SFML button
- * @param onDvmClick called when the user clicks the DVM button
+ * @param renderTypes the rendering types this Publication is available in
+ * @param onRenderTypeClick called with the rendering type the user chose to view
  */
 @Composable
 fun PublicationCard(
@@ -48,8 +53,8 @@ fun PublicationCard(
     validFrom: Date?,
     validTo: Date?,
     tags: List<String> = emptyList(),
-    onSfmlClick: (() -> Unit)?,
-    onDvmClick: (() -> Unit)?,
+    renderTypes: List<RenderingMetadataType>,
+    onRenderTypeClick: (RenderingMetadataType) -> Unit,
 ) {
     OutlinedCard(modifier = modifier.fillMaxWidth()) {
         Row(modifier = Modifier.padding(8.dp), verticalAlignment = Alignment.CenterVertically) {
@@ -91,22 +96,40 @@ fun PublicationCard(
                 Text(text = "Tags: ${tags.joinToString(",")}", style = Typography.bodySmall)
             }
         }
-        Row(
-            modifier =
-                Modifier
-                    .padding(8.dp)
-                    .align(Alignment.CenterHorizontally),
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
-        ) {
-            Button(enabled = onSfmlClick != null, onClick = onSfmlClick ?: {}) {
-                Text("View SFML", textAlign = TextAlign.Center)
-            }
-            Button(enabled = onDvmClick != null, onClick = onDvmClick ?: {}) {
-                Text("View DVM", textAlign = TextAlign.Center)
+        if (renderTypes.isNotEmpty()) {
+            @OptIn(ExperimentalLayoutApi::class)
+            FlowRow(
+                modifier =
+                    Modifier
+                        .padding(8.dp)
+                        .fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                renderTypes.forEach { renderType ->
+                    Button(
+                        onClick = { onRenderTypeClick(renderType) },
+                        contentPadding = ButtonDefaults.TextButtonContentPadding,
+                        modifier = Modifier.defaultMinSize(minWidth = 1.dp, minHeight = 1.dp),
+                    ) {
+                        Text(renderType.displayName(), fontSize = 12.sp)
+                    }
+                }
             }
         }
     }
 }
+
+/**
+ * A human-readable label for a rendering type
+ */
+fun RenderingMetadataType.displayName(): String =
+    when (this) {
+        RenderingMetadataType.SFML_VERTICAL -> "SFML Vertical"
+        RenderingMetadataType.SFML_HORIZONTAL -> "SFML Horizontal"
+        RenderingMetadataType.DVM_TEMPLATE -> "DVM Template"
+        RenderingMetadataType.DVM_STATIC -> "DVM Static"
+    }
 
 @Composable
 @Preview
@@ -118,7 +141,11 @@ fun PublicationCardPreview() {
         publicationId = "01J91Y4TX5BBZ4ZVK6JKCYGPAA",
         validFrom = Date(),
         validTo = Date(),
-        onDvmClick = {},
-        onSfmlClick = {},
+        renderTypes =
+            listOf(
+                RenderingMetadataType.DVM_TEMPLATE,
+                RenderingMetadataType.SFML_VERTICAL,
+            ),
+        onRenderTypeClick = {},
     )
 }

--- a/app/src/main/java/com/flipp/dvm/sample/android/ui/screens/DvmSampleApp.kt
+++ b/app/src/main/java/com/flipp/dvm/sample/android/ui/screens/DvmSampleApp.kt
@@ -93,6 +93,7 @@ fun DvmSampleApp(
                 PublicationScreen(
                     identifiers = route.identifiers,
                     renderType = route.renderType,
+                    language = route.language,
                     viewModel = viewModel,
                 )
             }

--- a/app/src/main/java/com/flipp/dvm/sample/android/ui/screens/PublicationListScreen.kt
+++ b/app/src/main/java/com/flipp/dvm/sample/android/ui/screens/PublicationListScreen.kt
@@ -20,12 +20,12 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
+import com.flipp.content.v2.model.CorePublication
 import com.flipp.dvm.sample.android.UiState
 import com.flipp.dvm.sample.android.navigation.Routes
 import com.flipp.dvm.sample.android.ui.composables.PublicationCard
-import com.flipp.dvm.sdk.android.external.models.Publication
-import com.flipp.dvm.sdk.android.external.models.RenderType
 import com.flipp.dvm.sdk.android.external.toIdentifiers
+import java.util.Date
 
 /**
  * A composable function that displays a list of publications
@@ -38,7 +38,7 @@ import com.flipp.dvm.sdk.android.external.toIdentifiers
 @Composable
 fun PublicationListScreen(
     modifier: Modifier = Modifier,
-    uiState: UiState<Publication>,
+    uiState: UiState<CorePublication>,
     storeCode: String,
     navController: NavHostController = rememberNavController(),
 ) {
@@ -92,47 +92,26 @@ fun PublicationListScreen(
                         style = MaterialTheme.typography.labelLarge,
                     )
                 }
-                items(publications) {
-                    val sfmlClickHandler =
-                        if (it.renderingTypes.contains(RenderType.SFML)) {
-                            {
-                                navController.navigate(
-                                    Routes.PublicationScreen(
-                                        it.toIdentifiers(
-                                            storeCode,
-                                        ),
-                                        RenderType.SFML,
-                                    ),
-                                )
-                            }
-                        } else {
-                            null
-                        }
-                    val dvmClickHandler =
-                        if (it.renderingTypes.contains(RenderType.DVM)) {
-                            {
-                                navController.navigate(
-                                    Routes.PublicationScreen(
-                                        it.toIdentifiers(
-                                            storeCode,
-                                        ),
-                                        RenderType.DVM,
-                                    ),
-                                )
-                            }
-                        } else {
-                            null
-                        }
+                items(publications) { publication ->
                     PublicationCard(
-                        imageUrl = it.details.imageUrl,
-                        name = it.details.name,
-                        publicationId = it.globalId,
-                        description = it.details.description,
-                        validFrom = it.dates.validFrom,
-                        validTo = it.dates.validTo,
-                        tags = it.tags,
-                        onSfmlClick = sfmlClickHandler,
-                        onDvmClick = dvmClickHandler,
+                        imageUrl = publication.details.imageUrl,
+                        name = publication.details.name,
+                        publicationId = publication.globalId,
+                        description = publication.details.description,
+                        // v2 dates are epoch seconds
+                        validFrom = publication.dates.validFrom?.let { Date(it * 1000) },
+                        validTo = publication.dates.validTo?.let { Date(it * 1000) },
+                        tags = publication.tags,
+                        renderTypes = publication.renderingMetadataTypes,
+                        onRenderTypeClick = { renderType ->
+                            navController.navigate(
+                                Routes.PublicationScreen(
+                                    identifiers = publication.toIdentifiers(storeCode),
+                                    renderType = renderType.name,
+                                    language = publication.language,
+                                ),
+                            )
+                        },
                     )
                 }
             }

--- a/app/src/main/java/com/flipp/dvm/sample/android/ui/screens/PublicationScreen.kt
+++ b/app/src/main/java/com/flipp/dvm/sample/android/ui/screens/PublicationScreen.kt
@@ -1,79 +1,74 @@
 package com.flipp.dvm.sample.android.ui.screens
 
+import android.content.Intent
+import android.net.Uri
 import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.flipp.content.v2.model.Offer
+import com.flipp.content.v2.model.Promotion
+import com.flipp.content.v2.model.RenderingMetadataType
 import com.flipp.dvm.sample.android.MainViewModel
 import com.flipp.dvm.sample.android.ui.composables.ItemDetails
-import com.flipp.dvm.sdk.android.external.PublicationRendererDelegate
 import com.flipp.dvm.sdk.android.external.FlippPublication
 import com.flipp.dvm.sdk.android.external.PublicationController
 import com.flipp.dvm.sdk.android.external.PublicationError
 import com.flipp.dvm.sdk.android.external.PublicationIdentifiers
-import com.flipp.dvm.sdk.android.external.models.Offer
-import com.flipp.dvm.sdk.android.external.models.RenderType
+import com.flipp.dvm.sdk.android.external.PublicationRendererDelegate
+import java.util.Date
 
 /**
  * A composable function that displays a publication screen with debug information
  *
  * @param modifier the modifier
  * @param identifiers values that uniquely identify a Publication
- * @param renderType the type of rendering method to use when displaying the publication
+ * @param renderType the name of the [RenderingMetadataType] to render the Publication with
+ * @param language the language to render the Publication in, e.g en, fr
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PublicationScreen(
     modifier: Modifier = Modifier,
     identifiers: PublicationIdentifiers,
-    renderType: RenderType,
+    renderType: String,
+    language: String = "en",
     viewModel: MainViewModel,
 ) {
     LaunchedEffect(Unit) {
         viewModel.selectedOffer.value = null
     }
 
+    val context = LocalContext.current
     val currentOffer by viewModel.selectedOffer.collectAsStateWithLifecycle()
 
-    val onFinishLoadToast = Toast.makeText(LocalContext.current, "DvmRendererDelegate: onFinishLoad", Toast.LENGTH_SHORT)
-    val onFailedToLoad = Toast.makeText(LocalContext.current, "DvmRendererDelegate: onFailedToLoad", Toast.LENGTH_SHORT)
-    val onTap = Toast.makeText(LocalContext.current, "DvmRendererDelegate: onTap", Toast.LENGTH_SHORT)
-    val onTapError = Toast.makeText(LocalContext.current, "DvmRendererDelegate: onTapError", Toast.LENGTH_SHORT)
-
-    val hotSwapRenderType = rememberSaveable { mutableStateOf(renderType) }
+    val onFinishLoadToast = Toast.makeText(context, "DvmRendererDelegate: onFinishLoad", Toast.LENGTH_SHORT)
+    val onFailedToLoad = Toast.makeText(context, "DvmRendererDelegate: onFailedToLoad", Toast.LENGTH_SHORT)
+    val onTap = Toast.makeText(context, "DvmRendererDelegate: onTap", Toast.LENGTH_SHORT)
+    val onTapError = Toast.makeText(context, "DvmRendererDelegate: onTapError", Toast.LENGTH_SHORT)
 
     Column(modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally) {
-        Button(onClick = {
-            if (hotSwapRenderType.value == RenderType.DVM) {
-                hotSwapRenderType.value = RenderType.SFML
-            } else {
-                hotSwapRenderType.value = RenderType.DVM
-            }
-        }) { Text("Toggle Render Type") }
         FlippPublication(
-            modifier = Modifier,
+            modifier = Modifier.fillMaxSize(),
             identifiers = identifiers,
-            renderType = hotSwapRenderType.value,
+            renderType = RenderingMetadataType.valueOf(renderType),
+            language = language,
             delegate =
                 object : PublicationRendererDelegate {
                     override fun onFinishLoad(
                         controller: PublicationController,
-                        legacyIdMap: Map<Long, String>?
+                        legacyIdMap: Map<Long, String>?,
                     ) {
                         onFinishLoadToast.show()
                     }
@@ -84,9 +79,27 @@ fun PublicationScreen(
                     }
 
                     override fun onTap(offer: Offer) {
-                        onTap.setText(offer.details?.name)
+                        onTap.setText(offer.details.name)
                         onTap.show()
                         viewModel.selectedOffer.value = offer
+                    }
+
+                    override fun onTap(promotion: Promotion) {
+                        onTap.setText(promotion.details?.name)
+                        onTap.show()
+                    }
+
+                    // Called when the user taps a take-to-merchant target within the Publication
+                    override fun onTap(url: String) {
+                        runCatching {
+                            context.startActivity(
+                                Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
+                                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                                },
+                            )
+                        }.onFailure {
+                            Log.w("onTap", "Failed to open url: $url", it)
+                        }
                     }
 
                     override fun onTapError(error: String) {
@@ -104,22 +117,22 @@ fun PublicationScreen(
             }) {
                 val listOfImageUrls =
                     mutableListOf<String>().apply {
-                        it.details?.imageUrl?.let { add(it) }
-                        it.details?.additionalMedia?.mapNotNull { media -> media.url }
-                            ?.let { addAll(it) }
+                        it.details.imageUrl?.let { add(it) }
+                        addAll(it.details.additionalMedia.mapNotNull { media -> media.url })
                     }.toList()
                 ItemDetails(
                     modifier = Modifier.fillMaxWidth(),
-                    name = it.details?.name,
-                    description = it.details?.description,
+                    name = it.details.name,
+                    description = it.details.description,
                     images = listOfImageUrls,
                     id = it.globalId,
                     pricing = it.pricing,
                     offerDetails = it.offerDetails,
                     details = it.details,
-                    validFrom = it.dates?.validFrom,
-                    validTo = it.dates?.validTo,
-                    disclaimer = it.offerDetails?.disclaimer,
+                    // v2 dates are epoch seconds
+                    validFrom = it.dates?.validFrom?.let { seconds -> Date(seconds * 1000) },
+                    validTo = it.dates?.validTo?.let { seconds -> Date(seconds * 1000) },
+                    disclaimer = it.offerDetails.disclaimer,
                 )
             }
         }

--- a/app/src/main/res/drawable/content_copy.xml
+++ b/app/src/main/res/drawable/content_copy.xml
@@ -3,7 +3,7 @@
     android:height="24dp"
     android:viewportWidth="960"
     android:viewportHeight="960"
-    android:tint="?attr/colorControlNormal"
+    android:tint="?android:attr/colorControlNormal"
     android:autoMirrored="true">
   <path
       android:fillColor="@android:color/white"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,19 +1,19 @@
 [versions]
-dvmSdk = "1.9.0"
+dvmSdk = "2.1.0"
 lifecycleViewmodelCompose = "2.8.6"
 navigationCompose = "2.8.2"
 coil = "2.7.0"
 kotlinxSerializationJson = "1.7.3"
 
-agp = "8.7.2"
-kotlin = "2.0.0"
-coreKtx = "1.10.1"
+agp = "8.9.3"
+kotlin = "2.2.20"
+coreKtx = "1.16.0"
 junit = "4.13.2"
-junitVersion = "1.1.5"
-espressoCore = "3.5.1"
-lifecycleRuntimeKtx = "2.6.1"
-activityCompose = "1.8.0"
-composeBom = "2024.04.01"
+junitVersion = "1.2.1"
+espressoCore = "3.6.1"
+lifecycleRuntimeKtx = "2.8.6"
+activityCompose = "1.9.2"
+composeBom = "2024.09.02"
 
 [libraries]
 dvm-sdk = { module = "com.flipp:dvm-sdk", version.ref = "dvmSdk" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Nov 04 17:08:16 EST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,11 +16,16 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+
+        // The SDK itself (com.flipp:dvm-sdk).
+        // Credentials are read from ~/.gradle/gradle.properties so they are never committed:
+        //   artifactory_user=[PROVIDED BY FLIPP]
+        //   artifactory_password=[PROVIDED BY FLIPP]
         maven {
             url = uri("https://flipplib.jfrog.io/artifactory/dvm-sdk-android")
             credentials {
-                username = ""        // TODO: Artifactory username provided by Flipp
-                password = ""        // TODO: Artifactory password provided by Flipp
+                username = providers.gradleProperty("artifactory_user").orNull ?: ""
+                password = providers.gradleProperty("artifactory_password").orNull ?: ""
             }
         }
     }
@@ -28,4 +33,3 @@ dependencyResolutionManagement {
 
 rootProject.name = "DVM Sample"
 include(":app")
- 


### PR DESCRIPTION
Updates the public sample app for `com.flipp:dvm-sdk:2.1.0`. The previous state targeted 1.9.0 and no longer compiled against 2.x.